### PR TITLE
Expose this to composer with a working composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "drupal/media",
+  "name": "drupal-media/media",
   "description": "Media module for Drupal",
   "type": "drupal-module",
   "homepage": "https://github.com/drupal-media/media/",
@@ -8,6 +8,20 @@
   },
   "license": "GPL-2.0+",
   "minimum-stability": "dev",
-  "require": { }
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packagist.drupal-composer.org"
+    }
+  ],
+  "require": {
+    "drupal/image_widget_crop": "^8.1",
+    "drupal/entity_embed": "^8.1@alpha",
+    "drupal/entity_browser": "8.1.x-dev",
+    "drupal/media_entity_image": "^8.1",
+    "drupal/media_entity_document": "^8.1",
+    "drupal/video_embed_field": "^8.1",
+    "drupal/media_entity_twitter": "^8.1",
+    "drupal/media_entity_instagram": "^8.1"
+  }
 }
-


### PR DESCRIPTION
Eventually this module will likely be on D.O. proper, I'm guessing, but until then, this would make pulling this module in with composer work!

Usage in the composer.json for your project would be:

```
"repositories": [
       ...
        {
            "type": "git",
            "url": "https://github.com/drupal-media/media.git"
        },
        ...
    ],
 ...
"require": {
        ...
        "drupal-media/media": "dev-8.x-1.x",
        ...
    },
```

I had to change the name from `drupal/media` to `drupal-media/media` because looking for `drupal/media` was only searching the drupal packages, and was only finding media v.7.

There might be a better way to solve this.
